### PR TITLE
using webdriverio 4.9.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "lodash": "4.17.4",
     "mocha": "4.1.0",
     "request": "2.83.0",
-    "webdriverio": "^4.9.11"
+    "webdriverio": "4.9.11"
   },
   "optionalDependencies": {
     "bugsnag": "^2.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2434,7 +2434,7 @@ wdio-dot-reporter@~0.0.8:
   version "0.0.9"
   resolved "https://registry.npmjs.org/wdio-dot-reporter/-/wdio-dot-reporter-0.0.9.tgz#929b2adafd49d6b0534fda068e87319b47e38fe5"
 
-webdriverio@^4.9.11:
+webdriverio@4.9.11:
   version "4.9.11"
   resolved "https://registry.npmjs.org/webdriverio/-/webdriverio-4.9.11.tgz#a828713c5a44be99afbe07eb5b523d5eccd04b44"
   dependencies:


### PR DESCRIPTION
`getValue` issue on iOS, comme https://github.com/webdriverio/webdriverio/issues/2574
à cause de https://github.com/webdriverio/webdriverio/pull/2493

figeons 4.9 pour l'instant